### PR TITLE
Improve compatibility: RxJS5, most.js, xstream and maybe more

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,11 @@ module.exports = function (val) {
 
 	var ret = [];
 
-	return new Promise(resolve => {
+	return new Promise((resolve, reject) => {
 		val[symbolObservable]()
 			.subscribe({
 				next: x => ret.push(x),
+				error: err => reject(err),
 				complete: () => resolve(ret)
 			});
 	});

--- a/index.js
+++ b/index.js
@@ -9,11 +9,11 @@ module.exports = function (val) {
 
 	var ret = [];
 
-	return val[symbolObservable]()
-		.forEach(function (x) {
-			ret.push(x);
-		})
-		.then(function () {
-			return ret;
-		});
+	return new Promise(resolve => {
+		val[symbolObservable]()
+			.subscribe({
+				next: x => ret.push(x),
+				complete: () => resolve(ret)
+			});
+	});
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "devDependencies": {
     "ava": "*",
     "is-promise": "^2.1.0",
+    "most": "^1.2.2",
+    "rxjs": "^5.2.0",
     "xo": "*",
     "xstream": "^10.2.0",
     "zen-observable": "^0.2.1"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ava": "*",
     "is-promise": "^2.1.0",
     "xo": "*",
+    "xstream": "^10.2.0",
     "zen-observable": "^0.2.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,16 +1,16 @@
 /**
  * Tests for observable-to-promise module
  *
- * function commonTests() contains tests which dont use any observables
+ * function commonTests() contains tests which don't use any observables
  *
- * function testLibs is invoked with the list of pairs: library name,
+ * function testLibs() is invoked with the list of : library name,
  * and fromArray fabric. To add test for one more library just pass
  * one more array to the `testLibs` function.
  */
 import test from 'ava';
 import isPromise from 'is-promise';
 
-import zenObservable from 'zen-observable';
+import ZenObservable from 'zen-observable';
 import xs from 'xstream';
 import Rx from 'rxjs';
 import * as most from 'most';
@@ -20,21 +20,29 @@ import toPromise from './';
 // for `zen-observable` on Node.js 0.10
 global.Promise = Promise;
 
-let array = [1, 2];
-
 /**
  * Run tests for a given observable library
  *
  * @param libName {string} the name of the lib under test
  * @param fromArray {(Array) => Observable} constructor of observable from array
+ * @param failed {() => Observable} returns an observable that terminates with error
  */
-function testOneLib([libName, fromArray]) {
+function testOneLib([libName, fromArray, failed]) {
+	let array = [1, 2];
+
 	test(`${libName}: observable to promise`, t => {
-		t.true(isPromise(toPromise(fromArray(array))));
+		let p = toPromise(fromArray(array));
+		t.true(isPromise(p));
 	});
 
 	test(`${libName}: passes values through`, async t => {
-		t.deepEqual(array, await toPromise(fromArray(array)));
+		let p = toPromise(fromArray(array));
+		t.deepEqual(array, await p);
+	});
+
+	test(`${libName}: rejects on error in observable`, t => {
+		let p = toPromise(failed());
+		t.throws(p);
 	});
 }
 
@@ -47,28 +55,36 @@ function testLibs(libs) {
 	libs.forEach(testOneLib);
 }
 
-/**
- * Run tests not related to any lib
- */
+/** Run tests not using any observables */
 function commonTests() {
 	test('throw an error when an non observable is given', async t => {
 		t.throws(() => toPromise(2), TypeError);
 	});
 }
 
-/* run tests that don't use any observables */
 commonTests();
 
-/* prepare the 'fromArray' constructor for each lib */
-let zenFrom = array => zenObservable.from(array);
+/* prepare constructors for each lib */
+let reason = 'Rejected for testing.';
+let rejected = () => Promise.reject(reason);
+
+let zenFrom = array => ZenObservable.from(array);
+let zenFailed = () => new ZenObservable(observer =>
+	observer.error(reason));
+
 let xsFrom = array => xs.from(array);
+let xsFailed = () => xs.fromPromise(rejected());
+
 let rxFrom = array => Rx.Observable.from(array);
+let rxFailed = () => Rx.Observable.fromPromise(rejected());
+
 let mostFrom = array => most.from(array);
+let mostFailed = () => most.fromPromise(rejected());
 
 /* finally, run the tests for all libs */
 testLibs([
-	['zenObservable', zenFrom],
-	['xstream', xsFrom],
-	['RxJS 5', rxFrom],
-	['most', mostFrom]
+	['zen-observable', zenFrom, zenFailed],
+	['xstream', xsFrom, xsFailed],
+	['RxJS 5', rxFrom, rxFailed],
+	['most', mostFrom, mostFailed]
 ]);

--- a/test.js
+++ b/test.js
@@ -3,9 +3,13 @@
  *
  * function commonTests() contains tests which don't use any observables
  *
- * function testLibs() is invoked with the list of : library name,
- * and fromArray fabric. To add test for one more library just pass
- * one more array to the `testLibs` function.
+ * function testWithLibs() invoked with array of items, that each contains
+ * library name and two functions:
+ * - constructor of observable from array: (Array) => Observable
+ * - constructor of observable which terminates with an error: () => Observable
+ *
+ * To add under the test one more library just prepare and pass one more array
+ * to the `testWithLibs` function.
  */
 import test from 'ava';
 import isPromise from 'is-promise';
@@ -24,10 +28,10 @@ global.Promise = Promise;
  * Run tests for a given observable library
  *
  * @param libName {string} the name of the lib under test
- * @param fromArray {(Array) => Observable} constructor of observable from array
+ * @param fromArray {(Array) => Observable} constructs observable from array
  * @param failed {() => Observable} returns an observable that terminates with error
  */
-function testOneLib([libName, fromArray, failed]) {
+function testWithALib([libName, fromArray, failed]) {
 	let array = [1, 2];
 
 	test(`${libName}: observable to promise`, t => {
@@ -51,8 +55,8 @@ function testOneLib([libName, fromArray, failed]) {
  *
  * @param libs {[libName, fromArray]}
  */
-function testLibs(libs) {
-	libs.forEach(testOneLib);
+function testWithLibs(libs) {
+	libs.forEach(testWithALib);
 }
 
 /** Run tests not using any observables */
@@ -81,8 +85,8 @@ let rxFailed = () => Rx.Observable.fromPromise(rejected());
 let mostFrom = array => most.from(array);
 let mostFailed = () => most.fromPromise(rejected());
 
-/* finally, run the tests for all libs */
-testLibs([
+/* finally, run tests with prepared constructors */
+testWithLibs([
 	['zen-observable', zenFrom, zenFailed],
 	['xstream', xsFrom, xsFailed],
 	['RxJS 5', rxFrom, rxFailed],

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ import isPromise from 'is-promise';
 import zenObservable from 'zen-observable';
 import xs from 'xstream';
 
-import m from './';
+import toPromise from './';
 
 // for `zen-observable` on Node.js 0.10
 global.Promise = Promise;
@@ -19,17 +19,17 @@ let array = [1, 2];
  */
 function testOneLib(libName, fromArray) {
 	test(`${libName}: observable to promise`, t => {
-		t.true(isPromise(m(fromArray(array))));
+		t.true(isPromise(toPromise(fromArray(array))));
 	});
 
 	test(`${libName}: passes values through`, async t => {
-		t.deepEqual(array, await m(fromArray(array)));
+		t.deepEqual(array, await toPromise(fromArray(array)));
 	});
 }
 
 function commonTests() {
 	test('throw an error when an non observable is given', async t => {
-		t.throws(() => m(2), TypeError);
+		t.throws(() => toPromise(2), TypeError);
 	});
 }
 

--- a/test.js
+++ b/test.js
@@ -3,6 +3,8 @@ import isPromise from 'is-promise';
 
 import zenObservable from 'zen-observable';
 import xs from 'xstream';
+import Rx from 'rxjs';
+import * as most from 'most';
 
 import toPromise from './';
 
@@ -34,7 +36,7 @@ function commonTests() {
 }
 
 /* run common tests */
-commonTests()
+commonTests();
 
 /* run tests for zenObservable */
 let zenFrom = array => zenObservable.from(array);
@@ -43,3 +45,11 @@ testOneLib('zenObservable', zenFrom);
 /* run tests for xstream */
 let xsFrom = array => xs.from(array);
 testOneLib('xstream', xsFrom);
+
+/* run tests for RxJS 5 */
+let rxFrom = array => Rx.Observable.from(array);
+testOneLib('RxJS 5', rxFrom);
+
+/* run tests for most */
+let mostFrom = array => most.from(array);
+testOneLib('most', mostFrom);

--- a/test.js
+++ b/test.js
@@ -1,3 +1,12 @@
+/**
+ * Tests for observable-to-promise module
+ *
+ * function commonTests() contains tests which dont use any observables
+ *
+ * function testLibs is invoked with the list of pairs: library name,
+ * and fromArray fabric. To add test for one more library just pass
+ * one more array to the `testLibs` function.
+ */
 import test from 'ava';
 import isPromise from 'is-promise';
 
@@ -19,7 +28,7 @@ let array = [1, 2];
  * @param libName {string} the name of the lib under test
  * @param fromArray {(Array) => Observable} constructor of observable from array
  */
-function testOneLib(libName, fromArray) {
+function testOneLib([libName, fromArray]) {
 	test(`${libName}: observable to promise`, t => {
 		t.true(isPromise(toPromise(fromArray(array))));
 	});
@@ -29,27 +38,37 @@ function testOneLib(libName, fromArray) {
 	});
 }
 
+/**
+ * Run tests for the list of libs
+ *
+ * @param libs {[libName, fromArray]}
+ */
+function testLibs(libs) {
+	libs.forEach(testOneLib);
+}
+
+/**
+ * Run tests not related to any lib
+ */
 function commonTests() {
 	test('throw an error when an non observable is given', async t => {
 		t.throws(() => toPromise(2), TypeError);
 	});
 }
 
-/* run common tests */
+/* run tests that don't use any observables */
 commonTests();
 
-/* run tests for zenObservable */
+/* prepare the 'fromArray' constructor for each lib */
 let zenFrom = array => zenObservable.from(array);
-testOneLib('zenObservable', zenFrom);
-
-/* run tests for xstream */
 let xsFrom = array => xs.from(array);
-testOneLib('xstream', xsFrom);
-
-/* run tests for RxJS 5 */
 let rxFrom = array => Rx.Observable.from(array);
-testOneLib('RxJS 5', rxFrom);
-
-/* run tests for most */
 let mostFrom = array => most.from(array);
-testOneLib('most', mostFrom);
+
+/* finally, run the tests for all libs */
+testLibs([
+	['zenObservable', zenFrom],
+	['xstream', xsFrom],
+	['RxJS 5', rxFrom],
+	['most', mostFrom]
+]);

--- a/test.js
+++ b/test.js
@@ -1,19 +1,45 @@
 import test from 'ava';
-import zenObservable from 'zen-observable';
 import isPromise from 'is-promise';
+
+import zenObservable from 'zen-observable';
+import xs from 'xstream';
+
 import m from './';
 
 // for `zen-observable` on Node.js 0.10
 global.Promise = Promise;
 
-test('observable to promise', t => {
-	t.true(isPromise(m(zenObservable.of(1, 2))));
-});
+let array = [1, 2];
 
-test('throw an error when an non observable is given', async t => {
-	t.throws(() => m(2), TypeError);
-});
+/**
+ * Run tests for a given observable library
+ *
+ * @param libName {string} the name of the lib under test
+ * @param fromArray {(Array) => Observable} constructor of observable from array
+ */
+function testOneLib(libName, fromArray) {
+	test(`${libName}: observable to promise`, t => {
+		t.true(isPromise(m(fromArray(array))));
+	});
 
-test('passes values through', async t => {
-	t.deepEqual(await m(zenObservable.of(1, 2)), [1, 2]);
-});
+	test(`${libName}: passes values through`, async t => {
+		t.deepEqual(array, await m(fromArray(array)));
+	});
+}
+
+function commonTests() {
+	test('throw an error when an non observable is given', async t => {
+		t.throws(() => m(2), TypeError);
+	});
+}
+
+/* run common tests */
+commonTests()
+
+/* run tests for zenObservable */
+let zenFrom = array => zenObservable.from(array);
+testOneLib('zenObservable', zenFrom);
+
+/* run tests for xstream */
+let xsFrom = array => xs.from(array);
+testOneLib('xstream', xsFrom);


### PR DESCRIPTION
## The Impetus
I've faced an issue in AVA [observable support](https://github.com/avajs/ava#observable-support). It works well with RxJS5 but doesn't work with [most](https://github.com/cujojs/most) and [xstream](https://github.com/staltz/xstream).

Partly the reason was in this lib: it relies on methods `.forEach()`, and `.then()`, which implemented not in all libraries. Using only `.subscribe` method appears more robust.

By the way, AVA and most/xstream still doesn't fixed for me. I've tested that by [`npm link`](https://docs.npmjs.com/cli/link)`.

## Tests
In this PR I've also refactored the tests to make it really easy to add more observable libraries under test. Although we may not need this when relying on just the `.subscribe()` method that is very basic and crucial for any implementation of observable.